### PR TITLE
Use clang-format to format ts code before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "servicenow-dev-skeleton",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Skeleton project for ServiceNow typescript development",
   "main": "dist/tasks.js",
   "author": "Bryce Godfrey",
@@ -33,8 +33,9 @@
     "chalk": "^2.3.2",
     "dotenv": "^5.0.0",
     "gulp": "^3.9.1",
-    "gulpclass": "^0.1.2",
+    "gulp-clang-format": "^1.0.25",
     "gulp-typescript": "^4.0.0",
+    "gulpclass": "^0.1.2",
     "request": "^2.85.0",
     "require-dir": "^1.0.0",
     "ts-simple-ast": "^9.1.0",

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -52,6 +52,28 @@ export class Gulpfile {
     }
     
     @Task()
+    format(){
+        const format = require('gulp-clang-format');
+
+        const clangFormat = {
+            Language: "JavaScript",
+            BasedOnStyle: "Mozilla",
+            AllowShortFunctionsOnASingleLine: false,
+            BreakBeforeBraces: "Attach",
+            ColumnLimit: 150,
+            IndentWidth: 2,
+            JavaScriptQuotes: "Double",
+            MaxEmptyLinesToKeep: 1,
+            CommentPragmas: '^/<reference|^/<dts>'
+        };
+
+        return gulp
+                .src(this.config.src+'**/*.ts')
+                .pipe(format.format())
+                .pipe(gulp.dest(this.config.src));
+    }
+
+    @Task(undefined, ['format'])
     build(){
         const tsProject = gulpts.createProject(this.config.tsconfig, {
             typescript: require('typescript')


### PR DESCRIPTION
Add format gulp task.
Make build task depend on the format task.