### PR TITLE
Fix formatting stuff

### DIFF
--- a/bin/skeleton.js
+++ b/bin/skeleton.js
@@ -14,7 +14,7 @@ if(process.argv[process.argv.length-1] == 'init'){
 
     var appRoot = process.cwd();
 
-    var copyFiles = ['servicenowconfig.js', 'src/tsconfig.json', 'typings.json'];
+    var copyFiles = ['servicenowconfig.js', 'src/tsconfig.json', 'typings.json', 'tslint.json'];
     var sourceRoot = path.relative(appRoot, path.dirname(path.dirname(process.argv[1])));
 
     copyFiles.forEach(file => {

--- a/package.json
+++ b/package.json
@@ -35,17 +35,19 @@
     "gulp": "^3.9.1",
     "gulp-clang-format": "^1.0.25",
     "gulp-typescript": "^4.0.0",
+    "gulp-tslint": "^8.1.3",
     "gulpclass": "^0.1.2",
     "request": "^2.85.0",
     "require-dir": "^1.0.0",
     "ts-simple-ast": "^9.1.0",
+    "tslint": "^5.9.1",
     "typescript": "^2.7.2"
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",
     "@types/dotenv": "^4.0.2",
     "@types/gulp": "^4.0.5",
-    "@types/node": "^9.4.7",
+    "@types/node": "^9.6.2",
     "@types/request": "^2.47.0",
     "typings": "^2.1.1"
   }

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -1,46 +1,49 @@
-import * as fs from 'fs';
-import * as dotenv from 'dotenv';
-import Project, { SyntaxKind } from 'ts-simple-ast';
-import {Gulpclass, Task, SequenceTask} from 'gulpclass';
+import {default as chalk} from "chalk";
+import * as dotenv from "dotenv";
+import * as fs from "fs";
 import * as gulp from "gulp";
+import * as gulpts from "gulp-typescript";
+import {Gulpclass, SequenceTask, Task} from "gulpclass";
 import * as path from "path";
 import * as request from "request";
-import * as gulpts from 'gulp-typescript';
-import {default as chalk} from 'chalk';
+import Project, { SyntaxKind } from "ts-simple-ast";
 
 if (fs.existsSync(".env")) {
-	dotenv.config()
+  dotenv.config();
 }
 
 @Gulpclass()
 export class Gulpfile {
     private config: any;
     constructor() {
-        const path = require('path');   
-        const configPath = path.resolve('./servicenowconfig.js');     
-        this.config = require(configPath);  
-        
-        if(!this.config.src)
-            throw 'servicenowconfig.js missing "src" path property';
+        const path = require("path");
+        const configPath = path.resolve("./servicenowconfig.js");
+        this.config = require(configPath);
 
-        if(!this.config.out)
-            throw 'servicenowconfig.js missing "out" path property';
+        if (!this.config.src) {
+            throw "servicenowconfig.js missing \"src\" path property";
+        }
 
-        if(!this.config.tsconfig)
-            throw 'servicenowconfig.js missing "tsconfig" path property';
+        if (!this.config.out) {
+            throw "servicenowconfig.js missing \"out\" path property";
+        }
+
+        if (!this.config.tsconfig) {
+            throw "servicenowconfig.js missing \"tsconfig\" path property";
+        }
     }
 
-	@Task()
-	dts() {
+    @Task()
+  public dts() {
         return new Promise<void>((resolve, reject) => {
-            if(!this.checkUserSettings()){
-                reject('AUTHENTICATION NOT SET');
+            if (!this.checkUserSettings()){
+                reject("AUTHENTICATION NOT SET");
                 return;
             }
             else{
                 const types = this.getAllTypes();
                 console.info(chalk.yellow("Requesting type info from SN for: ") + types);
-                this.invokeServiceNow(`${this.config.uri}/api/avana/dev_integration/schema`, 'POST', { tables: types })
+                this.invokeServiceNow(`${this.config.uri}/api/avana/dev_integration/schema`, "POST", { tables: types })
                     .then(result => {
                         this.writeDTS(this.config.dts.sndts, this.config.dts.refs, this.config.dts.ignoreFields, result);
                         this.addReferenceToIndex(this.config.dts.sndts);
@@ -50,109 +53,158 @@ export class Gulpfile {
             }
         });
     }
-    
-    @Task()
-    format(){
-        const format = require('gulp-clang-format');
 
+    @Task()
+    public format(){
+        const format = require("gulp-clang-format");
         const clangFormat = {
-            Language: "JavaScript",
-            BasedOnStyle: "Mozilla",
             AllowShortFunctionsOnASingleLine: false,
+            BasedOnStyle: "Mozilla",
             BreakBeforeBraces: "Attach",
-            ColumnLimit: 150,
+            ColumnLimit: 500,
+            CommentPragmas: "^/<reference|^/<dts>",
             IndentWidth: 2,
             JavaScriptQuotes: "Double",
-            MaxEmptyLinesToKeep: 1,
-            CommentPragmas: '^/<reference|^/<dts>'
+            Language: "JavaScript",
+            MaxEmptyLinesToKeep: 1
         };
-
         return gulp
-                .src(this.config.src+'**/*.ts')
-                .pipe(format.format())
+                .src(this.config.src + "**/*.ts")
+                .pipe(format.format(clangFormat))
                 .pipe(gulp.dest(this.config.src));
     }
 
-    @Task(undefined, ['format'])
-    build(){
+    @Task()
+    public tslintfix(){
+        const tslint = require("tslint");
+        const gulpTsLint = require("gulp-tslint");
+
+        const program = tslint.Linter.createProgram("./tsconfig.json");
+
+        const tslintOptions = {
+            configuration: "./tslint.json",
+            fix: true,
+            formatter: "stylish",
+            formattersDirectory: null,
+            program: program,
+            rulesDirectory: null,
+            tslint: tslint
+        };
+
+        return gulp
+                .src(this.config.src + "**/*.ts")
+                .pipe(gulpTsLint(tslintOptions))
+                .pipe(gulpTsLint.report({
+                    allowWarnings: true
+                }));
+    }
+
+    @Task()
+    public tslint(){
+        const tslint = require("tslint");
+        const gulpTsLint = require("gulp-tslint");
+
+        const program = tslint.Linter.createProgram("./tsconfig.json");
+
+        const tslintOptions = {
+            configuration: "./tslint.json",
+            fix: false,
+            formatter: "stylish",
+            formattersDirectory: null,
+            program: program,
+            rulesDirectory: null,
+            tslint: tslint
+        };
+
+        return gulp
+                .src(this.config.src + "**/*.ts")
+                .pipe(gulpTsLint(tslintOptions))
+                .pipe(gulpTsLint.report({
+                    allowWarnings: true
+                }));
+    }
+
+    @Task(undefined, ["tslint"])
+    public build(){
         const tsProject = gulpts.createProject(this.config.tsconfig, {
-            typescript: require('typescript')
+            typescript: require("typescript")
         });
 
         return gulp
-                .src(this.config.src+'**/*.ts')
+                .src(this.config.src + "**/*.ts")
                 .pipe(tsProject(gulpts.reporter.defaultReporter()))
                 .pipe(gulp.dest(this.config.out));
     }
 
-    @Task(undefined, ['build'])
-    push() {
+    @Task(undefined, ["build"])
+    public push() {
         return this.pushToServiceNow();
     }
 
     @Task()
-    pull(){
+    public pull(){
         return this.pullFromServiceNow();
     }
 
     @SequenceTask()
-    sync() {
-        return ["pull", "dts"]
+    public sync() {
+        return ["pull", "dts"];
     }
 
     private pushToServiceNow(): Promise<any> {
         type UploadContent = {
-            id: string, 
-            etag: string, 
-            table: string, 
+            id: string,
+            etag: string,
+            table: string,
             fields: {
                 [key: string]: string
             }
         };
 
-        const upload : {[id: string]: UploadContent} = {};
+        const upload: {[id: string]: UploadContent} = {};
 
         const mappings = require(path.resolve(this.config.mapping)) as MappingFile;
 
         Object.keys(mappings)
             .forEach(id => {
                 const item = mappings[id];
-                if(!item || !item.fields)
+                if (!item || !item.fields) {
                     return;
+                }
 
-                const b : UploadContent = {
-                    id: id,
+                const b: UploadContent = {
                     etag: item.etag,
-                    table: item.type,
-                    fields: { }
+                    fields: { },
+                    id: id,
+                    table: item.type
                 };
-                
-                Object.keys(item.fields).forEach(key => {
-                    var filePath = item.fields[key];
-                    var ext = path.extname(filePath);
 
-                    if(!fs.existsSync(filePath)){
-                        if(ext == '.js'){
-                            filePath = filePath.substring(0, filePath.length - ext.length) + '.ts';
-                            ext = '.ts';
-                            if(!fs.existsSync(filePath)){
-                                throw 'Unable to find mapping with either a .js or .ts extension' + filePath;
+                Object.keys(item.fields).forEach(key => {
+                    let filePath = item.fields[key];
+                    let ext = path.extname(filePath);
+
+                    if (!fs.existsSync(filePath)){
+                        if (ext === ".js"){
+                            filePath = filePath.substring(0, filePath.length - ext.length) + ".ts";
+                            ext = ".ts";
+                            if (!fs.existsSync(filePath)){
+                                throw "Unable to find mapping with either a .js or .ts extension" + filePath;
                             }
                         }
                     }
 
-                    if(ext == '.ts' && (filePath.indexOf('.d.ts') == -1))
+                    if (ext === ".ts" && (filePath.indexOf(".d.ts") === -1))
                     {
-                        var distPath = filePath.replace(path.normalize(this.config.src), path.normalize(this.config.out));
-                        distPath = distPath.substring(0, distPath.length - ext.length) + '.js';
-                        if(!fs.existsSync(distPath)){
-                            throw 'Typescript output file was not found: ' + distPath;
+                        let distPath = filePath.replace(path.normalize(this.config.src), path.normalize(this.config.out));
+                        distPath = distPath.substring(0, distPath.length - ext.length) + ".js";
+                        if (!fs.existsSync(distPath)){
+                            throw "Typescript output file was not found: " + distPath;
                         }
-                        b.fields[key] = fs.readFileSync(distPath, 'utf8');
-                        b.fields[this.config.types[item.type][key].ts_field] = fs.readFileSync(filePath, 'utf8');
+                        b.fields[key] = fs.readFileSync(distPath, "utf8");
+                        b.fields[this.config.types[item.type][key].ts_field] = fs.readFileSync(filePath, "utf8");
                     }
                     else{
-                        b.fields[key] = fs.readFileSync(filePath, 'utf8');
+                        b.fields[key] = fs.readFileSync(filePath, "utf8");
                     }
                 });
 
@@ -162,15 +214,18 @@ export class Gulpfile {
         const uri = `${this.config.uri}/api/avana/dev_integration/application/${this.config.application}/files`;
 
         return this
-                .invokeServiceNow(uri, 'PUT', upload)
+                .invokeServiceNow(uri, "PUT", upload)
                 .then(result => {
                     Object.keys(result).forEach(key => {
-                        var item = result[key];
-                        if(item.etag_outofdate){
-                            console.warn(chalk.yellowBright(item.table + '\\' + item.name + ' is out of date! Use ' + chalk.white("gulp pull") + ' to syncronize with server'));
+                        const item = result[key];
+                        if (item.etag_outofdate){
+                            console.warn(chalk.yellowBright(item.table + "\\" + item.name +
+                                                            " is out of date! Use " +
+                                                            chalk.white("gulp pull") +
+                                                            " to syncronize with server"));
                         }
-                        else if(item.updated){
-                            console.info(item.table + '\\' + item.name + ' was updated');
+                        else if (item.updated){
+                            console.info(item.table + "\\" + item.name + " was updated");
                             mappings[key].etag = item.etag;
                         }
                     });
@@ -181,7 +236,7 @@ export class Gulpfile {
 
     private pullFromServiceNow(): Promise<any> {
         let mappings: MappingFile = {};
-        if(fs.existsSync(this.config.mapping)){
+        if (fs.existsSync(this.config.mapping)){
             mappings = require(path.resolve(this.config.mapping));
         }
 
@@ -191,9 +246,9 @@ export class Gulpfile {
 
         const uri = `${this.config.uri}/api/avana/dev_integration/application/${this.config.application}/files`;
         return Promise.all([
-            this.invokeServiceNow(uri, 'POST', body)
+            this.invokeServiceNow(uri, "POST", body)
                 .then(r => this.writePullResult(r, mappings))
-                .then(m => {                    
+                .then(m => {
                     fs.writeFileSync(this.config.mapping, JSON.stringify(m, undefined, 3));
                 }),
             this.getApplicationRefs(this.config.application)
@@ -201,18 +256,18 @@ export class Gulpfile {
     }
 
     private writePullResult(result: GetFilesResult, mappings: MappingFile): MappingFile{
-        if(!mappings.hasOwnProperty(result.sys_app.id) || (mappings[result.sys_app.id].etag != result.sys_app.etag)) {
-            console.log('Updating application typings file');
+        if (!mappings.hasOwnProperty(result.sys_app.id) || (mappings[result.sys_app.id].etag !== result.sys_app.etag)) {
+            console.log("Updating application typings file");
             mappings[this.config.application] = {
-                type: 'sys_app',
                 etag: result.sys_app.etag,
                 fields: {
-                    u_typings: 'typings.json',
-                    u_dts: this.config.dts.appdts
-                }
-            }
-            
-            fs.writeFileSync('typings.json', result.sys_app.fields.u_typings);
+                    u_dts: this.config.dts.appdts,
+                    u_typings: "typings.json"
+                },
+                type: "sys_app"
+            };
+
+            fs.writeFileSync("typings.json", result.sys_app.fields.u_typings);
             fs.writeFileSync(this.config.dts.appdts, result.sys_app.fields.u_dts);
 
             this.addReferenceToIndex(this.config.dts.appdts);
@@ -222,17 +277,17 @@ export class Gulpfile {
         Object.keys(result.files)
             .forEach(key => {
                 const typeFiles = result.files[key];
-                
+
                 typeFiles.forEach(t => {
-                    //Only update the file if the server version has changed from last sync
-                    if (!mappings.hasOwnProperty(t.id) || (mappings.hasOwnProperty(t.id) && mappings[t.id].etag != t.etag)) {
-                        console.log('Updated: ' + t.table + '\\' + t.name);
+                    // Only update the file if the server version has changed from last sync
+                    if (!mappings.hasOwnProperty(t.id) || (mappings.hasOwnProperty(t.id) && mappings[t.id].etag !== t.etag)) {
+                        console.log("Updated: " + t.table + "\\" + t.name);
                         const p = this.writeFile(t);
-                        if(p){
+                        if (p){
                             mappings[t.id] = {
-                                type: t.table,
                                 etag: t.etag,
-                                fields: p
+                                fields: p,
+                                type: t.table
                             };
                         }
                     }
@@ -245,16 +300,16 @@ export class Gulpfile {
     private getApplicationRefs(id: string): Promise<void> {
         const uri = `${this.config.uri}/api/avana/dev_integration/application/${id}/dependencies`;
 
-        return this.invokeServiceNow(uri, 'GET')
+        return this.invokeServiceNow(uri, "GET")
             .then(result => {
                 Object.keys(result).forEach(key => {
                     const appref = result[key];
-                    const dtsPath = 'typings/appdependencies/' + appref.name + '/index.d.ts';
-    
+                    const dtsPath = "typings/appdependencies/" + appref.name + "/index.d.ts";
+
                     if (!fs.existsSync(dtsPath)) {
                         this.mkdirpSync(path.dirname(dtsPath));
                     }
-    
+
                     fs.writeFileSync(dtsPath, appref.dts);
                     this.addReferenceToIndex(dtsPath);
                 });
@@ -263,31 +318,31 @@ export class Gulpfile {
 
     private writeFile(appDataItem: GetFile): {[field: string]: string} | null {
         const typeInfo = this.config.types[appDataItem.table];
-        const typePaths : {[field:string]:string} = {};
-    
+        const typePaths: {[field: string]: string} = {};
+
         if (!typeInfo) {
             return null;
         }
-    
-        const handleType = (fieldName: string, rootPath: string, fileName: string) : string => {
+
+        const handleType = (fieldName: string, rootPath: string, fileName: string): string => {
             const prop = typeInfo[fieldName];
             let content = appDataItem.fields[fieldName];
             let ext = prop.type;
-    
-            if(prop.ts_field && appDataItem.fields[prop.ts_field]){
+
+            if (prop.ts_field && appDataItem.fields[prop.ts_field]){
                 content = appDataItem.fields[prop.ts_field];
-                ext = 'ts';
+                ext = "ts";
             }
-            
-            const filePath = path.join(rootPath, (fileName + '.' + ext));
+
+            const filePath = path.join(rootPath, (fileName + "." + ext));
             this.mkdirpSync(path.dirname(filePath));
             fs.writeFileSync(filePath, content);
             return filePath;
-        }
-    
+        };
+
         const fieldKeys = Object.keys(typeInfo);
-        if(fieldKeys.length == 1){
-            const field = fieldKeys[0];  
+        if (fieldKeys.length === 1){
+            const field = fieldKeys[0];
             typePaths[field] = handleType(field, path.join(this.config.src, appDataItem.table), appDataItem.name);
         }
         else {
@@ -295,7 +350,7 @@ export class Gulpfile {
                 typePaths[key] = handleType(key, path.join(this.config.src, appDataItem.table, appDataItem.name), key);
             });
         }
-        
+
         return typePaths;
     }
 
@@ -309,48 +364,50 @@ export class Gulpfile {
             }
         }
     }
-	
-	private getAllTypes() : Array<string> {
-		let types : Array<string> = [];
-        let srcPath = this.config.src + '**/*.ts';
-        console.info(`loading types from ts files at ${srcPath}`);
-		const project = new Project({compilerOptions: {removeComments: false}});
-		project.addExistingSourceFiles(srcPath);
-        project.getSourceFiles()
+
+    private getAllTypes(): Array<string> {
+    let types: Array<string> = [];
+    const srcPath = this.config.src + "**/*.ts";
+    console.info(`loading types from ts files at ${srcPath}`);
+    const project = new Project({compilerOptions: {removeComments: false}});
+    project.addExistingSourceFiles(srcPath);
+    project.getSourceFiles()
             .forEach(file => {
-                //find all new expressions and see if they are gliderecord:  const foo = new GlideRecord('sometable');
+                // find all new expressions and see if they are gliderecord:  const foo = new GlideRecord('sometable');
                 const news = file.getDescendantsOfKind(SyntaxKind.NewExpression);
                 news.forEach(n => {
                     const ext = n.getExpression();
                     const name = ext.getText();
-                    if(name == 'GlideRecord' || name == 'GlideRecordSecure'){
+                    if (name === "GlideRecord" || name === "GlideRecordSecure"){
                         const args = n.getArguments();
-                        if(args.length > 0){
+                        if (args.length > 0){
                             const atype = args[0].getType();
                             let aname = atype.getText();
-                            if(aname.charAt(0) == '"' || aname.charAt(0) == "'")
-                                aname = aname.substr(1, aname.length-2);
+                            if (aname.charAt(0) === "\"" || aname.charAt(0) === "'") {
+                                aname = aname.substr(1, aname.length - 2);
+                            }
 
-                            if(types.indexOf(aname) == -1 && aname != 'string')
+                            if (types.indexOf(aname) === -1 && aname !== "string") {
                                 types.push(aname);
+                            }
                         }
                     }
                 });
 
-                //Find all dts comment defs: /**dts: tablename1,tablename2 */
+                // Find all dts comment defs: /**dts: tablename1,tablename2 */
                 const dtsregex = new RegExp(/dts:[\s+]?([\w,\d\s]+)/gi);
 
                 const comments = file.getDescendantsOfKind(SyntaxKind.JSDocComment);
                 comments.forEach(comment => {
                     const content = comment.getText().trim();
                     let match = dtsregex.exec(content);
-                    while(match != null){
+                    while (match != null){
                         const matchtypes = match[1];
                         const matches = matchtypes
                             .trim()
-                            .split(',')
+                            .split(",")
                             .map(m => m.trim())
-                            .filter(m => types.indexOf(m) == -1);
+                            .filter(m => types.indexOf(m) === -1);
 
                         types = types.concat(matches);
 
@@ -359,13 +416,13 @@ export class Gulpfile {
                 });
             });
 
-		return types;
-	}
+    return types;
+  }
 
     private writeDTS(target: string, references: Array<string>, ignoreFields: Array<string>, definitions: any) {
         let dts = references
                     .map(ref => `///<reference path="${ref}" />`)
-                    .join('\r\n');
+                    .join("\r\n");
 
         dts += "\r\n\r\ndeclare module sn {\r\n" +
             "\texport module Server {\r\n" +
@@ -384,11 +441,15 @@ export class Gulpfile {
             const fields = Object.keys(def.fields).sort();
             fields.forEach(fieldname => {
                 const fielddef = def.fields[fieldname];
-                if (ignoreFields.indexOf(fieldname) == -1 && 
-                    (!def.superclass || (definitions.hasOwnProperty(def.superclass) && !definitions[def.superclass].fields.hasOwnProperty(fieldname)))) {
+                if (ignoreFields.indexOf(fieldname) === -1
+                    && (!def.superclass
+                        || (definitions.hasOwnProperty(def.superclass)
+                        && !definitions[def.superclass].fields.hasOwnProperty(fieldname))
+                        )
+                    ) {
                     let type = fielddef.type;
                     if (type.match(/IGlide/g)) {
-                        type = `string`;
+                            type = `string`;
                     }
 
                     dts += `\t\t\t${fieldname}: sn.Server.IGlideElement & ${type}`;
@@ -405,8 +466,9 @@ export class Gulpfile {
         dts += "\t}\r\n}";
 
         const targetdir = path.dirname(target);
-        if(!fs.existsSync(targetdir))
+        if (!fs.existsSync(targetdir)) {
             fs.mkdirSync(targetdir);
+        }
 
         fs.writeFileSync(target, dts);
         console.log(chalk.green("DTS saved to: " + target));
@@ -418,28 +480,28 @@ export class Gulpfile {
                 fs.writeFileSync("./.env", "SN_USER=\r\nSN_PASSWORD=");
             }
 
-            console.error(chalk.red("ERROR: SN_USER and/or SN_PASSWORD env constiables are not set!  Please update your .env file with your ServiceNow basic auth credentials!"));
+            console.error(chalk.red("ERROR: SN_USER and/or SN_PASSWORD env constiables are not set! Please update your .env file with your ServiceNow basic auth credentials!"));
             return false;
         }
         return true;
     }
 
-    private invokeServiceNow(uri: string, method: 'GET'|'POST'|'PUT', body?: any) : Promise<any> {
+    private invokeServiceNow(uri: string, method: "GET"|"POST"|"PUT", body?: any): Promise<any> {
         return new Promise<any>((resolve, reject) => {
             request(
                 {
-                    url: uri,
-                    method: method,
                     body: body,
-                    json: true,
                     headers: {
-                        "Content-Type": "application/json",
                         "Accept": "application/json",
-                        "Authorization": "Basic " + (new Buffer(process.env.SN_USER + ":" + process.env.SN_PASSWORD)).toString("base64")
-                    }
+                        "Authorization": "Basic " + (new Buffer(process.env.SN_USER + ":" + process.env.SN_PASSWORD)).toString("base64"),
+                        "Content-Type": "application/json"
+                    },
+                    json: true,
+                    method: method,
+                    url: uri
                 },
                 (err, response, b) => {
-                    if (!err && response.statusCode == 200) {
+                    if (!err && response.statusCode === 200) {
                         resolve(b.result);
                     }
                     else {
@@ -450,29 +512,28 @@ export class Gulpfile {
     }
 
     private addReferenceToIndex(referencePath: string) {
-        const pathToIndex = 'typings/index.d.ts';
+        const pathToIndex = "typings/index.d.ts";
         let write = false;
-    
-        //Get the path relative to the index file
+
+        // Get the path relative to the index file
         const relativePath = path.relative(path.dirname(pathToIndex), path.dirname(referencePath));
-    
-        //Check if the path already exists
-        const regexPath = 'path=[\'"]' + path.join(relativePath, path.basename(referencePath)).replace(/\\/g, '\\\\') + '[\'"]';
-        const appdtsRegex = new RegExp(regexPath, 'g');
-    
-        let content = fs.readFileSync(pathToIndex, 'utf8');
-    
+
+        // Check if the path already exists
+        const regexPath = "path=['\"]" + path.join(relativePath, path.basename(referencePath)).replace(/\\/g, "\\\\") + "['\"]";
+        const appdtsRegex = new RegExp(regexPath, "g");
+
+        let content = fs.readFileSync(pathToIndex, "utf8");
+
         if (!appdtsRegex.test(content)) {
-            content += '\r\n/// <reference path="' + path.join(relativePath, path.basename(referencePath)) + '" />';
+            content += "\r\n/// <reference path=\"" + path.join(relativePath, path.basename(referencePath)) + "\" />";
             write = true;
         }
-    
+
         if (write) {
             fs.writeFileSync(pathToIndex, content);
         }
     }
 }
-
 
 type MappingFile = {
     [sysid: string]: {
@@ -482,8 +543,7 @@ type MappingFile = {
             [field: string]: string;
         }
     }
-}
-
+};
 
 type GetFilesResult = {
     sys_app: {
@@ -497,7 +557,7 @@ type GetFilesResult = {
     files: {
         [type: string]: Array<GetFile>
     }
-}
+};
 
 type GetFile = {
     id: string;
@@ -507,4 +567,4 @@ type GetFile = {
     fields: {
         [fieldName: string]: string;
     }
-}
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,9 @@
         "experimentalDecorators": true,
         "rootDir": "src",
         "sourceMap": true,
-        "outDir": "dist"
+        "outDir": "dist",
+        "moduleResolution": "node",
+        "lib": ["es2016"]
     },
     "include": [
         "src",

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,102 @@
+{
+    "defaultSeverity": "error",
+    "extends": "tslint:recommended",
+    "jsRules": {},
+    "rules": {
+        "arrow-parens": [
+            true,
+            "ban-single-arg-parens"
+        ],
+        "align": [
+            true,
+            "members",
+            "parameters",
+            "statements"
+        ],
+        "array-type": [
+            true,
+            "generic"
+        ],
+        "ban-comma-operator": true,
+        "ban-types": [
+            true,
+            [
+                "Object",
+                "Use {} instead."
+            ],
+            [
+                "String",
+                "Use 'string' instead."
+            ],
+            [
+                "Number",
+                "Use 'number' instead."
+            ],
+            [
+                "Boolean",
+                "Use 'boolean' instead."
+            ]
+        ],
+        "curly": [true, "ignore-same-line"],
+        "cyclomatic-complexity": { 
+            "options": true, 
+            "severity": "warning" 
+        },
+        "forin": { 
+            "options": true, 
+            "severity": "warning" 
+        },
+        "indent": [
+            true,
+            "spaces",
+            2
+        ],
+        "interface-over-type-literal": false,
+        "jsdoc-format": true,
+        "max-classes-per-file": false,
+        "max-line-length": { "options": [150], "severity": "warning" },
+        "no-bitwise": false,
+        "no-conditional-assignment": true,
+        "no-console": false,
+        "no-eval": false,
+        "no-internal-module": false,
+        "no-namespace": false,
+        "no-reference": false,
+        "no-shadowed-variable": false,
+        "no-string-throw": false,
+        "no-var-keyword": true,
+        "one-line": false,
+        "object-literal-shorthand": [true, "never"],
+        "only-arrow-functions": [
+            true,
+            "allow-declarations",
+            "allow-named-functions"
+        ],
+        "prefer-for-of": false,
+        "quotemark": [
+            true,
+            "double"
+        ],
+        "radix": false,
+        "semicolon": [true, "always", "ignore-bound-class-methods"],
+        "switch-default": true,
+        "trailing-comma": [
+            true,
+            {
+                "multiline": "never",
+                "singleline": "never"
+            }
+        ],
+        "triple-equals": [
+            true,
+            "allow-null-check"
+        ],
+        "whitespace": [
+            true,
+            "check-branch",
+            "check-operator",
+            "check-rest-spread"
+        ]
+    },
+    "rulesDirectory": []
+}

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {},
   "globalDependencies": {
-    "servicenowserver": "github:bryceg/servicenow-dts/server/scoped-helsinki/index.d.ts#v2.1"
+    "servicenowserver": "github:bryceg/servicenow-dts/server/scoped-helsinki/index.d.ts#v2.2"
   }
 }


### PR DESCRIPTION
Build now automatically runs tslint and will break on tslint errors. It will succeed on warnings.

There is a default tslint.json rule configuration that is copied into the project by init, but the settings can be manipulated (or disabled) after init is run. This will allow for other teams to use this project and no longer modifies source files at build.

There is still a gulp format task that can be used to do a bulk format of all files, and a tslintfix task that will run tslint with the --fix flag set to true. This can fix up the simple issues (quote styles, == vs ===, const/let/var) in one go, but has to be manually run.