### PR TITLE
Minor cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Initial Project Setup
 ### Node Project Setup
 ```bash
-npm i servicenow-dev-skeleton --save-dev
+npm i servicenow-dev-skeleton require-dir --save-dev
 node_modules\.bin\skeleton init
 typings install
 ```

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -63,7 +63,7 @@ export class Gulpfile {
             BreakBeforeBraces: "Attach",
             ColumnLimit: 500,
             CommentPragmas: "^/<reference|^/<dts>",
-            IndentWidth: 4,
+            IndentWidth: 2,
             JavaScriptQuotes: "Double",
             Language: "JavaScript",
             MaxEmptyLinesToKeep: 1

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -129,7 +129,8 @@ export class Gulpfile {
         const tsProject = gulpts.createProject(this.config.tsconfig, {
             typescript: require("typescript")
         });
-
+        console.log("Building with TypeScript compiler version " + tsProject.typescript.version);
+        
         return gulp
                 .src(this.config.src + "**/*.ts")
                 .pipe(tsProject(gulpts.reporter.defaultReporter()))

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -63,7 +63,7 @@ export class Gulpfile {
             BreakBeforeBraces: "Attach",
             ColumnLimit: 500,
             CommentPragmas: "^/<reference|^/<dts>",
-            IndentWidth: 2,
+            IndentWidth: 4,
             JavaScriptQuotes: "Double",
             Language: "JavaScript",
             MaxEmptyLinesToKeep: 1

--- a/src/tasks.ts
+++ b/src/tasks.ts
@@ -522,13 +522,13 @@ export class Gulpfile {
         const relativePath = path.relative(path.dirname(pathToIndex), path.dirname(referencePath));
 
         // Check if the path already exists
-        const regexPath = "path=['\"]" + path.join(relativePath, path.basename(referencePath)).replace(/\\/g, "\\\\") + "['\"]";
+        const regexPath = "path=['\"]" + path.join(relativePath, path.basename(referencePath)).replace(/\\/g, "/") + "['\"]";
         const appdtsRegex = new RegExp(regexPath, "g");
 
         let content = fs.readFileSync(pathToIndex, "utf8");
 
         if (!appdtsRegex.test(content)) {
-            content += "\r\n/// <reference path=\"" + path.join(relativePath, path.basename(referencePath)) + "\" />";
+            content += "\r\n/// <reference path=\"" + path.join(relativePath, path.basename(referencePath)).replace(/\\/g, "/") + "\" />";
             write = true;
         }
 

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,7 @@
 {
-  "dependencies": {},
-  "globalDependencies": {
-    "servicenowserver": "github:bryceg/servicenow-dts/server/scoped-helsinki/index.d.ts#v2.2"
+    "dependencies": {},
+    "globalDependencies": {
+      "servicenowserver": "github:bryceg/servicenow-dts/server/scoped-jakarta/index.d.ts#v2.2"
+    }
   }
-}
+  

--- a/typings.json
+++ b/typings.json
@@ -1,7 +1,7 @@
 {
     "dependencies": {},
     "globalDependencies": {
-      "servicenowserver": "github:bryceg/servicenow-dts/server/scoped-jakarta/index.d.ts#v2.2"
+      "servicenowserver": "github:bryceg/servicenow-dts/server/scoped-jakarta/index.d.ts#v2.4"
     }
   }
   


### PR DESCRIPTION
- Include require-dir npm package on npm install command
- Use ServiceNow Jarkarta TypeScript Definitions
- Log TypeScript compiler version during build task
- Use forward slash for index reference paths to fix intellisense